### PR TITLE
style(MinerrPass): remove unnecessary \" wrapping MINERR_URL

### DIFF
--- a/src/org/angularjs/closurerunner/MinerrPass.java
+++ b/src/org/angularjs/closurerunner/MinerrPass.java
@@ -48,7 +48,7 @@ class MinerrPass extends AbstractPostOrderCallback implements CompilerPass {
     "      prefix = '[' + (module ? module + ':' : '') + code + '] ',\n" +
     "      message,\n" +
     "      i = 1;\n" +
-    "    message = prefix + '\"MINERR_URL\"' + (module ? module + '/' : '') + code;\n" +
+    "    message = prefix + 'MINERR_URL' + (module ? module + '/' : '') + code;\n" +
     "    for(; i < arguments.length; i++) {\n" +
     "      message = message + (i == 1 ? '?' : '&') + 'p' + (i-1) + '=' + stringify(arguments[i]);\n" +
     "    }\n" +
@@ -80,7 +80,7 @@ class MinerrPass extends AbstractPostOrderCallback implements CompilerPass {
   }
 
   static String substituteInSource(String url) {
-    return MINERR_SOURCE.replace("\"MINERR_URL\"", url);
+    return MINERR_SOURCE.replace("MINERR_URL", url);
   }
 
   private Node createSubstituteMinerrDefinition() {


### PR DESCRIPTION
In the MINERR_SOURCE template, there is a placeholder that will be
replaced with a url that is passed into the tool.  Currently the placeholder
is \"MINERR_URL\".  The extra escaped quotes are not necessary and can be
confusing, given that the template is already a javascript function inside
a java string.

This wasn't actually causing the failure on the Windows machine.
That is to be fixed in the grunt-util.js but this change will just make it easier to maintain this codebase.
