### PR TITLE
feat(NgClosureRunner): add flag for colon separator

### DIFF
--- a/src/org/angularjs/closurerunner/MinerrPass.java
+++ b/src/org/angularjs/closurerunner/MinerrPass.java
@@ -48,7 +48,7 @@ class MinerrPass extends AbstractPostOrderCallback implements CompilerPass {
     "      prefix = '[' + (module ? module + ':' : '') + code + '] ',\n" +
     "      message,\n" +
     "      i = 1;\n" +
-    "    message = prefix + 'MINERR_URL' + (module ? module + '/' : '') + code;\n" +
+    "    message = prefix + 'MINERR_URL' + (module ? module + 'MINERR_SEPARATOR' : '') + code;\n" +
     "    for(; i < arguments.length; i++) {\n" +
     "      message = message + (i == 1 ? '?' : '&') + 'p' + (i-1) + '=' + stringify(arguments[i]);\n" +
     "    }\n" +
@@ -79,8 +79,14 @@ class MinerrPass extends AbstractPostOrderCallback implements CompilerPass {
     this(compiler, errorConfigOutput, null);
   }
 
+  static String substituteInSource(String url, String separator) {
+    return MINERR_SOURCE
+            .replace("MINERR_URL", url)
+            .replace("MINERR_SEPARATOR", separator);
+  }
+
   static String substituteInSource(String url) {
-    return MINERR_SOURCE.replace("MINERR_URL", url);
+    return substituteInSource(url, "/");
   }
 
   private Node createSubstituteMinerrDefinition() {

--- a/src/org/angularjs/closurerunner/NgClosureRunner.java
+++ b/src/org/angularjs/closurerunner/NgClosureRunner.java
@@ -18,15 +18,17 @@ import java.util.List;
 public class NgClosureRunner extends CommandLineRunner {
 
   private boolean minerrPass;
-  private String minerrErrors, minerrUrl;
+  private String minerrErrors, minerrUrl, minerrSeparator;
   private Compiler cachedCompiler;
 
   protected NgClosureRunner(String[] args, 
                             boolean minerrPass, 
                             String minerrErrors, 
-                            String minerrUrl) {
+                            String minerrUrl,
+                            String minerrSeparator) {
     super(args);
     this.minerrPass = minerrPass;
+    this.minerrSeparator = minerrSeparator;
     
     if (minerrErrors != null) {
       this.minerrErrors = minerrErrors;
@@ -41,7 +43,9 @@ public class NgClosureRunner extends CommandLineRunner {
     PrintStream output = new PrintStream(minerrErrors);
 
     if (minerrUrl != null) {
-      return new MinerrPass(compiler, output, MinerrPass.substituteInSource(minerrUrl));
+      return new MinerrPass(compiler,
+                            output,
+                            MinerrPass.substituteInSource(minerrUrl, minerrSeparator));
     }
     return new MinerrPass(compiler, output);
   }
@@ -77,7 +81,7 @@ public class NgClosureRunner extends CommandLineRunner {
 
   public static void main(String[] args) {
     boolean minerrPass = false;
-    String minerrErrors = "errors.json", minerrUrl = null;
+    String minerrErrors = "errors.json", minerrUrl = null, minerrSeparator = "/";
     List<String> passthruArgs = new ArrayList<String>();
 
     for (int i = 0; i < args.length; i++) {
@@ -88,13 +92,15 @@ public class NgClosureRunner extends CommandLineRunner {
         minerrErrors = args[++i];
       } else if (arg.equals("--minerr_url")) {
         minerrUrl = args[++i];
+      } else if (arg.equals("--minerr_separate_with_colon")) {
+        minerrSeparator = ":";
       } else {
         passthruArgs.add(arg);
       }
     }
 
     NgClosureRunner runner = new NgClosureRunner(passthruArgs.toArray(new String[]{}), 
-      minerrPass, minerrErrors, minerrUrl);
+      minerrPass, minerrErrors, minerrUrl, minerrSeparator);
 
     if (runner.shouldRunCompiler()) {
       runner.run();


### PR DESCRIPTION
Makes minErr urls work with our legacy scheme. :unamused:

This feature is behind a flag to generally discourage use, because I don't like it.
